### PR TITLE
Remove GC tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Collects stats on the event loop lag, garbage collection events, and memory stat
 
 ### Table of contents
 
-* [Installation](#installation)
-* [Usage](#usage)
-* [Setup](#setup)
-* [API](#api)
-  * [Registration API](#registration-api)
-    * [`NodePerformanceEmitter`](#nodeperformanceemitter)
-    * [`NodePerformanceEmitterToken`](#nodeperformanceemittertoken)
-  * [Dependencies](#dependencies)
-    * [`UniversalEventsToken`](#universaleventstoken)
-    * [`TimersToken`](#timerstoken)
-    * [`EventLoopLagIntervalToken`](#eventlooplagintervaltoken)
-    * [`SocketIntervalToken`](#socketintervaltoken)
-  * [Events](#events)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Setup](#setup)
+- [API](#api)
+  - [Registration API](#registration-api)
+    - [`NodePerformanceEmitter`](#nodeperformanceemitter)
+    - [`NodePerformanceEmitterToken`](#nodeperformanceemittertoken)
+  - [Dependencies](#dependencies)
+    - [`UniversalEventsToken`](#universaleventstoken)
+    - [`TimersToken`](#timerstoken)
+    - [`EventLoopLagIntervalToken`](#eventlooplagintervaltoken)
+    - [`SocketIntervalToken`](#socketintervaltoken)
+  - [Events](#events)
 
 ---
 
@@ -42,13 +42,13 @@ import {createPlugin} from 'fusion-core';
 import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 
 export default createPlugin({
-  deps: { emitter: UniversalEventsToken },
+  deps: {emitter: UniversalEventsToken},
   provides: deps => {
     const emitter = deps.emitter;
     emitter.on('node-performance-emitter:{action}', e => {
       console.log(e); // log events to console
     });
-  }
+  },
 });
 ```
 
@@ -125,8 +125,8 @@ Optional. Server-only. Register a `setInterval`/`clearInterval` implementation. 
 ```js
 type Timers = {
   setInterval: (Function, number) => number,
-  clearInterval: (number) => void,
-}
+  clearInterval: number => void,
+};
 ```
 
 ##### `EventLoopLagIntervalToken`
@@ -162,7 +162,6 @@ This package has no public API methods. To consume performance events, add an ev
 - `node-performance-emitter:gauge:externalMemory` - process.memoryUsage().external
 - `node-performance-emitter:gauge:heapTotal` - process.memoryUsage().heapTotal
 - `node-performance-emitter:gauge:heapUsed` - process.memoryUsage().heapUsed
-- `node-performance-emitter:timing:gc` - time spent doing garbage collection
 - `node-performance-emitter:gauge:globalAgentSockets` - http.globalAgent.sockets
 - `node-performance-emitter:gauge:globalAgentRequests`- http.globalAgent.requests
 - `node-performance-emitter:gauge:globalAgentFreeSockets`- http.globalAgent.freeSockets

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
   },
   "dependencies": {
-    "assert": "^1.4.1",
-    "gc-profiler": "^1.4.0"
+    "assert": "^1.4.1"
   },
   "devDependencies": {
     "babel-eslint": "8.2.6",

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -211,37 +211,3 @@ test('service - tracking emit messages', t => {
     t.end();
   });
 });
-
-test('service - testing garbage collection emits', t => {
-  const mockEmitter = mockEmitterFactory();
-  const mockTimers = mockTimersFactory();
-  const appCreator = () => {
-    const app = new App('content', el => el);
-    app.register(TimersToken, mockTimers);
-    app.register(UniversalEventsToken, mockEmitter);
-    registerMockConfig(app);
-    return app;
-  };
-
-  // Register to listen to emits
-  let gcMessageReceived = false;
-  mockEmitter.on(`${EVENT_PLUGIN_NAME}:timing:gc`, () => {
-    gcMessageReceived = true;
-  });
-
-  const perfService = getService(appCreator, NodePerformanceEmitterPlugin);
-  perfService.startTrackingGCUsage();
-
-  // Make some garbage!
-  var myTracker = [];
-  for (var i = 0; i < 1000000; i++) {
-    myTracker.push({lotsof: 'garbage'});
-  }
-  myTracker = [];
-
-  setTimeout(() => {
-    perfService.stopTrackingGCUsage();
-    t.assert(gcMessageReceived, 'gc: message was received');
-    t.end();
-  }, 100);
-});

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,6 @@
 /* Configuration Tokens */
 // $FlowFixMe flow should be aware of native timers module
 import nodeTimers from 'timers';
-import profiler from 'gc-profiler';
 // $FlowFixMe flow should be aware of http.globalAgent property
 import {globalAgent} from 'http';
 import assert from 'assert';
@@ -95,14 +94,12 @@ class NodePerformanceEmitter {
   start() {
     this.startTrackingEventLoopLag();
     this.startTrackingMemoryUsage();
-    this.startTrackingGCUsage();
     this.startTrackingSocketUsage();
   }
 
   stop() {
     this.stopTrackingEventLoopLag();
     this.stopTrackingMemoryUsage();
-    this.stopTrackingGCUsage();
     this.stopTrackingSocketUsage();
   }
 
@@ -158,27 +155,6 @@ class NodePerformanceEmitter {
     this.emit('gauge:rss', memoryUsage.rss);
     this.emit('gauge:heapTotal', memoryUsage.heapTotal);
     this.emit('gauge:heapUsed', memoryUsage.heapUsed);
-  }
-
-  /* Tracking Garbage Collection */
-  startTrackingGCUsage() {
-    if (this.isTrackingGarbageCollection)
-      throw new Error(
-        'Garbage Collection is already being tracked.  Please stop previous instance before beginning a new one.'
-      );
-
-    profiler.on('gc', info => {
-      this.emit('timing:gc', {
-        duration: info.duration,
-        type: info.type,
-        forced: info.forced,
-      });
-    });
-  }
-
-  stopTrackingGCUsage() {
-    profiler.removeAllListeners('gc');
-    this.isTrackingGarbageCollection = false;
   }
 
   /* Tracking Socket Usage */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,12 +2515,6 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gc-profiler@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gc-profiler/-/gc-profiler-1.4.0.tgz#1a8c4965a8d792b3be6138f8e8ae27ea861731a6"
-  dependencies:
-    nan "^2.0.8"
-
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -3654,7 +3648,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.8, nan@^2.9.2:
+nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 


### PR DESCRIPTION
Turns out keeping a reference to the gc-profiler has serious performance implications for applications and tests. Removing this profiling should prove beneficial to both production and development performance.

I don't believe GC tracking is a valuable metric to measure and profile in-app, a better method of doing this would be for heap analysis on running processes.