### PR TITLE
Switch to gc-stats module

### DIFF
--- a/docs/migrations/00138.md
+++ b/docs/migrations/00138.md
@@ -1,0 +1,13 @@
+#### Changes to garbage collection events
+
+We've changed our garbage collection library and the `node-performance-emitter:timing:gc` event now reports data differently.
+
+The following fields have been updated:
+
+- type: will now be one of the following values([v8 source](https://github.com/nodejs/node/blob/554fa24916c5c6d052b51c5cee9556b76489b3f7/deps/v8/include/v8.h#L6137-L6144)):
+  - 1: Scavenge (minor GC)
+  - 2: Mark/Sweep/Compact (major GC)
+  - 4: Incremental marking
+  - 8: Weak/Phantom callback processing
+  - 15: All
+- forced: This field has been removed.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "assert": "^1.4.1",
-    "gc-profiler": "^1.4.0"
+    "gc-stats": "^1.2.0"
   },
   "devDependencies": {
     "babel-eslint": "8.2.6",

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -225,7 +225,9 @@ test('service - testing garbage collection emits', t => {
 
   // Register to listen to emits
   let gcMessageReceived = false;
-  mockEmitter.on(`${EVENT_PLUGIN_NAME}:timing:gc`, () => {
+  let totalDuration = 0;
+  mockEmitter.on(`${EVENT_PLUGIN_NAME}:timing:gc`, args => {
+    totalDuration += args.duration;
     gcMessageReceived = true;
   });
 
@@ -242,6 +244,7 @@ test('service - testing garbage collection emits', t => {
   setTimeout(() => {
     perfService.stopTrackingGCUsage();
     t.assert(gcMessageReceived, 'gc: message was received');
+    t.assert(totalDuration > 0, 'gc: total duration is greater than 0');
     t.end();
   }, 100);
 });

--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,7 @@
 /* Configuration Tokens */
 // $FlowFixMe flow should be aware of native timers module
 import nodeTimers from 'timers';
-import profiler from 'gc-profiler';
+import gcStats from 'gc-stats';
 // $FlowFixMe flow should be aware of http.globalAgent property
 import {globalAgent} from 'http';
 import assert from 'assert';
@@ -58,6 +58,8 @@ function eventLoopLag(cb: Function) {
 }
 
 function noop() {}
+
+const gc = gcStats();
 
 /* Service */
 class NodePerformanceEmitter {
@@ -167,17 +169,16 @@ class NodePerformanceEmitter {
         'Garbage Collection is already being tracked.  Please stop previous instance before beginning a new one.'
       );
 
-    profiler.on('gc', info => {
+    gc.on('stats', stats => {
       this.emit('timing:gc', {
-        duration: info.duration,
-        type: info.type,
-        forced: info.forced,
+        duration: stats.pauseMS,
+        type: stats.gctype,
       });
     });
   }
 
   stopTrackingGCUsage() {
-    profiler.removeAllListeners('gc');
+    gc.removeAllListeners('stats');
     this.isTrackingGarbageCollection = false;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1711,6 +1711,10 @@ deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -2515,11 +2519,12 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gc-profiler@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gc-profiler/-/gc-profiler-1.4.0.tgz#1a8c4965a8d792b3be6138f8e8ae27ea861731a6"
+gc-stats@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gc-stats/-/gc-stats-1.2.0.tgz#c32845148f3f842064d5aafcc427306e523894f4"
   dependencies:
-    nan "^2.0.8"
+    nan "^2.10.0"
+    node-pre-gyp "^0.10.0"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -3654,7 +3659,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.8, nan@^2.9.2:
+nan@^2.10.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
+
+nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -3682,6 +3691,14 @@ natural-compare@^1.4.0:
 needle@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.0.tgz#f14efc69cee1024b72c8b21c7bdf94a731dc12fa"
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
+needle@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.3.tgz#c1b04da378cd634d8befe2de965dc2cfb0fd65ca"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -3756,6 +3773,21 @@ node-mocks-http@^1.6.6:
     parseurl "^1.3.1"
     range-parser "^1.2.0"
     type-is "^1.6.14"
+
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4"
 
 node-pre-gyp@^0.9.0:
   version "0.9.1"
@@ -4288,6 +4320,15 @@ rc@^1.1.7:
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.6.tgz#eb18989c6d4f4f162c399f79ddd29f3835568092"
   dependencies:
     deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  dependencies:
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"


### PR DESCRIPTION
The old `gc-profiler` module has performance issues at startup, causing tests to run very slow. The `gc-stats` module on the other hand seems to not have these performance issues and also resolves some issues with stuck tests.